### PR TITLE
disqus added

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ description: 'Stories rund um die Softwareentwicklung bei der SBB CFF FFS'
 url: 'https://SchweizerischeBundesbahnen.github.io'
 baseurl: '/'
 google_analytics: 'UA-113933653-1'
-# disqus_shortname: 'your-disqus-name'
+disqus_shortname: 'techblog-sbb-ch'
 
 author:
   name: 'SBB Informatik - Softwareengineering'

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+comments: true
 ---
 <article class="post-container post-container--single">
   <header class="post-header">


### PR DESCRIPTION
Sollte laufen, zumindest ging es lokal bei mir (wobei die Seite CSS-Seitig lokal nicht gut aussieht, LInks gebrochen sind, etc.: Aber das sollte ein anderes Thema sein):
- Gastkommentare sind deaktiviert: Man muss diese moderieren. Automoderation, was das wohl kann, kostet aber. Ich würde mal damit starten. Kommentieren kann man nach Login via OAUTH und Google, Facebook, Disqus und Twitter.
- Die meisten Settings gehen via Disqus.com. Evt. will noch eine andere Email dort als Admin eingetragen werden? herbert@sbb.ch ? Einfach registrieren und melden. Einige Settings (Mails für Sharing, etc.) brauchen evt. noch Feinschliff und auch die Moderation sollte evt. verteilt werden.